### PR TITLE
Luxor edge driver v2

### DIFF
--- a/profiles/luxor-controller.yml
+++ b/profiles/luxor-controller.yml
@@ -35,6 +35,15 @@ preferences:
       minLength: 7
       maxLength: 15
       default: "192.168.1.xxx"
+  - title: "Polling Refresh Rate"
+    name: refreshRate
+    description: "Polling Refresh Rate (s) -- Actively poll controller for status every X seconds."
+    required: true
+    preferenceType: integer
+    definition:
+      minimum: 30
+      maximum: 86400
+      default: 300
   - title: "Spawn New Controller Device"
     name: duplicate
     description: "Toggle on, and then off to spawn another controller device"


### PR DESCRIPTION
After writing 3 other edge smartthings drivers, I learned more about the structure and timing of the edge driver framework.

The first version of this driver put too much work on the "driver" object itself rather than letting the controller device be the center of functionality.

The new code is now very controller-centric and should support multiple controllers easily.

The new version also now uses thread call-backs plus child device architecture to pass light levels to child devices rather than shuttle them through driver-level hash tables.

Questions and suggestions are welcome, but this is still provided as is. :) [Though note that it's in heavy use at my own house.]